### PR TITLE
sm84xx-common: Fix touch dead issue after turn off the screen

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -157,6 +157,7 @@ TW_INCLUDE_RESETPROP := true
 TW_USE_SERIALNO_PROPERTY_FOR_DEVICE_ID := true
 TW_OVERRIDE_SYSTEM_PROPS := \
     "ro.build.fingerprint=ro.vendor.build.fingerprint;ro.build.version.incremental"
+TW_NO_SCREEN_BLANK := true
 RECOVERY_LIBRARY_SOURCE_FILES += \
     $(TARGET_OUT_SHARED_LIBRARIES)/android.hidl.allocator@1.0.so \
     $(TARGET_OUT_SHARED_LIBRARIES)/android.hidl.memory@1.0.so \


### PR DESCRIPTION
Touchpanel driver suspends touchscreen to low power state on entering TWRP and dead after 1st turn off. TW_NO_SCREEN_BLANK seems to fix this in userspace